### PR TITLE
Fix H2443 hint in 10.4 Sydney

### DIFF
--- a/Utils.JSON.pas
+++ b/Utils.JSON.pas
@@ -29,7 +29,7 @@ unit Utils.JSON;
 interface
 
 uses
-  System.SysUtils, System.JSON, System.TypInfo;
+  System.SysUtils, System.JSON, System.TypInfo, System.Generics.Collections;
 
 type
   TJSONType = (
@@ -388,7 +388,7 @@ type
 implementation
 
 uses
-  System.StrUtils, System.Generics.Collections;
+  System.StrUtils;
 
 {$REGION 'Internal Helper Functions'}
 function FormatType(AType: TJSONType): String;


### PR DESCRIPTION
Looks like TJsonArray.GetValue(..) was inlined and requires System.Generics.Collections to be in the interface section. Should not affect previous Delphi versions and only remove a hint for 10.4.
 
_(and for some strange reasons, some line breaks from the previous commit are fixed, whether I want it or not)_